### PR TITLE
Tested working fix for remaining issue in #23.

### DIFF
--- a/.docksal/docksal-local.yml.sample
+++ b/.docksal/docksal-local.yml.sample
@@ -4,6 +4,8 @@
 ## Exposed cli environment variables needed:
 ##  * HOST - Hosting environment name (e.g. 'pantheon')
 ##  * PANTHEON_SITE_NAME - for pantheon sites
+##  * GH_TOKEN - blocks reference git branch commit during PR for core-update
+##  * TRAVIS_EVENT_TYPE - needed  for travis cron run
 version: "2.1"
 
 services:
@@ -11,4 +13,5 @@ services:
     environment:
       - HOST
       - PANTHEON_SITE_NAME
+      - TRAVIS_EVENT_TYPE
       - GH_TOKEN


### PR DESCRIPTION
## Summary of changes

1. Exposed an important environment variable in Travis that detects cron run (`$TRAVIS_EVENT_TYPE`) to docksal cli container. Without it, Travis cron trigger is unknown to 'fin drupal-coreupdate' and fail core update detection and PR.


## Notes
Tested working in branch coreupdate_TROUBLESHOOT5 (configured to run as Travis cron) which in turn created PR for coreupdate 8.9.7 (https://github.com/promet/provus/pull/44)


## To test

- [x] See notes earlier

### Pull request author

As the author, I have verified the following (if applicable):

- [ ] Behat/Cypress test(s) are added/modified
- [ ] Unit test(s) are added/modified
- [ ] WCAG2AA test(s) are added/modified

### Pull request reviewer

As the reviewer, I have verified the following:

- [ ] I have tested the PR locally and/or in a staging environment
