### PR TITLE
Fix cyprss install script

### DIFF
--- a/scripts/bin/install-cypress.sh
+++ b/scripts/bin/install-cypress.sh
@@ -2,5 +2,6 @@
 
 source ${PROJECT_ROOT}/scripts/bin/env.sh
 
+sudo apt-get update
 sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 cd ${PROJECT_ROOT}/tests/cypress; npm i 


### PR DESCRIPTION
The cypress install script started failing because the dependencies were not being installed correctly. Adding ``apt-get update`` fixes this.