### PR TITLE
Pantheon hook

### DIFF
--- a/hooks/pantheon/deploy.php
+++ b/hooks/pantheon/deploy.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ *
+ * Run updates on pantheon when code changes.
+ */
+
+// Import all config changes.
+echo "Importing configuration from yml files...\n";
+passthru('drush config-import -y');
+echo "Import of configuration complete.\n";
+//Clear all cache
+echo "Rebuilding cache.\n";
+passthru('drush cr');
+echo "Rebuilding cache complete.\n";

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -2,3 +2,10 @@
 # For more information, see: https://pantheon.io/docs/pantheon-yml/
 api_version: 1
 web_docroot: true
+
+workflows:
+  deploy:
+    after:
+      - type: webphp
+        description: Run project specific updates. 
+        script: hooks/pantheon/deploy.php


### PR DESCRIPTION
## Summary of changes

1. Adds pantheon Quicksilver commands: https://pantheon.io/docs/quicksilver
When a pantheon env is updated, we want to automatically to run commands like cache clear and config import

To enable this, add “workflows” to your pantheon.yml file

```
workflows:
  sync_code:
    after:
      - type: webphp
        description: Run project specific updates.
        script: private/deploy.php
```

## Notes

* Should add to docs

