### PR TITLE
PSPRO01-234 remove Do not use from Provus menus module.

### DIFF
--- a/web/profiles/provus/modules/custom/provus_core/provus_menus/provus_menus.provus_extension.yml
+++ b/web/profiles/provus/modules/custom/provus_core/provus_menus/provus_menus.provus_extension.yml
@@ -1,3 +1,3 @@
-name: Provus Menus - Do not select
-description: Provus Menus - Do not select
+name: Provus Menus
+description: Provus Menus
 default: true


### PR DESCRIPTION
## JIRA
 
https://prometprojects.atlassian.net/browse/PSPRO01-234
## Summary of changes

1.  remove "do not use" warning on provus menu select box during setup

## Notes


## To test

- [ ] 
- [ ] 
- [ ] 

### Pull request author

As the author, I have verified the following (if applicable):

- [ ] Behat/Cypress test(s) are added/modified
- [ ] Unit test(s) are added/modified
- [ ] WCAG2AA test(s) are added/modified

### Pull request reviewer

As the reviewer, I have verified the following:

- [x ] I have tested the PR locally and/or in a staging environment
