### PR TITLE
PSPRO01-265: Set new card display for 4 card featured.

### DIFF
--- a/web/profiles/provus/modules/custom/provus_core/provus_blocks/provus_blocks.module
+++ b/web/profiles/provus/modules/custom/provus_core/provus_blocks/provus_blocks.module
@@ -453,10 +453,10 @@ function _provus_blocks_groups_format_content($type, $id_array, $storage, $view_
     if (!empty($entity)) {
       $item_display = $vars['display_content'];
       if ($group_display == 'featured_4' && $key == 0) {
-        $item_display = 'card';
+        $item_display = 'provus_card';
       }
       elseif ($group_display == 'featured_4' && $key > 0) {
-        $item_display = 'card_left';
+        $item_display = 'provus_card_left';
       }
       if ($type == 'block') {
         $block_build['content'] = $view_builder->view($entity, 'default');


### PR DESCRIPTION
## JIRA
 
https://prometprojects.atlassian.net/browse/PSPRO01-265

## Summary of changes

1. Set new card display for 4 card featured.

## Notes

When we changed the names of our cards, we forgot that the 4 card featured display sets those names automatically in the code.  We need a better way of handling this configuration change so that we don't hard code these names, but for now this will fix our current issue.

## To test

- [ ] Create a landing page
- [ ] Add a Group component
- [ ] Add cards into the group
- [ ] Set the Group display to be '4 Card Featured'
- [ ] Save
- [ ] Confirm the layout is a larger card on left and on the right the cards are with image left and text right
- [ ] 

### Pull request author

As the author, I have verified the following (if applicable):

- [ ] Behat/Cypress test(s) are added/modified
- [ ] Unit test(s) are added/modified
- [ ] WCAG2AA test(s) are added/modified

### Pull request reviewer

As the reviewer, I have verified the following:

- [ ] I have tested the PR locally and/or in a staging environment
